### PR TITLE
Upgrading container structure tests to 1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:3.11.2
 
 RUN apk add curl
 
-RUN curl -LO https://storage.googleapis.com/container-structure-test/v1.8.0/container-structure-test-linux-amd64 \
+RUN curl -LO https://storage.googleapis.com/container-structure-test/v1.9.0/container-structure-test-linux-amd64 \
     && chmod +x container-structure-test-linux-amd64 \
     && mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test


### PR DESCRIPTION
Hey,

Found your action on the GitHub store, rather than creating my own thought I'd upgrade yours to the latest (1.9.0) so I can use it as well!

Thanks,