### PR TITLE
Bump container-structure-test version to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.17
 
-ARG CST_VERSION=1.16.0
+ARG CST_VERSION=1.19.1
 RUN apk add --no-cache curl \
     && curl -sSL https://storage.googleapis.com/container-structure-test/v${CST_VERSION}/container-structure-test-linux-amd64 -o /usr/local/bin/container-structure-test \
     && chmod +x /usr/local/bin/container-structure-test \


### PR DESCRIPTION
Thanks for this action, just a version bump ♥️